### PR TITLE
 #3 Add support for *.test extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 					"tcl"
 				],
 				"extensions": [
-					".tcl"
+					".tcl",
+					".test"
 				],
 				"configuration": "./tcl.configuration.json"
 			}


### PR DESCRIPTION
The [tcltest](http://wiki.tcl.tk/1502) package is a Tcl test framework, which supports `*.test` extension for the test cases.
